### PR TITLE
Update kos-software.json

### DIFF
--- a/kos-software.json
+++ b/kos-software.json
@@ -135,6 +135,7 @@
   },
   {
     "name": "OntoPortal Alliance",
+    "url": "https://ontoportal.org/",
     "platform": "Web",
     "api": true,
     "edit": false,

--- a/kos-software.json
+++ b/kos-software.json
@@ -123,7 +123,7 @@
     "update": "2024"
   },
   {
-    "name": "Ontology Look-up Service (OLS)",
+    "name": "Ontology Lookup Service (OLS)",
     "url": "https://github.com/EBISPOT/ols4",
     "platform": "Web",
     "api": true,
@@ -134,7 +134,7 @@
     "update": "2025"
   },
   {
-    "name": "OntoPortal Appliance",
+    "name": "OntoPortal Alliance",
     "platform": "Web",
     "api": true,
     "edit": false,


### PR DESCRIPTION
I corrected the name for OLS and OntoPortal. In addition I also added the url for the OntoPortal webpage: https://ontoportal.org/

`The Ontology Lookup Service (OLS) is a repository for biomedical ontologies that aims to provide a single point of access to the latest ontology versions.`
Source: https://www.ebi.ac.uk/ols4

`The OntoPortal Alliance is dedicated to promoting semantic and ontology services based on the open, collaboratively developed OntoPortal technology.`
Source: https://github.com/ontoportal