### PR TITLE
Update voc4cat, vocexcel & fix typos

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -63,7 +63,7 @@ df = df.applymap(cell)
 display(HTML(df.to_html(escape=False,index=False)))
 ```
 
-The following applications, scripts, and/or libraries may also worth to consider for KOS management but they have not been evaluated yet enough to be inclued in the list above:
+The following applications, scripts, and/or libraries may also worth to consider for KOS management but they have not been evaluated yet enough to be included in the list above:
 
 - SSSOM (Python)
 - TS4NFDI API Gateway
@@ -103,7 +103,7 @@ The following software products support editing, viewing and/or analyzing contro
 
 ### Generic software
 
-Simple terminologies can be managed in a **spreadsheet** (LibreOffice Calc, Excel, Google Sheets...). This software lacks most special functionality for terminology management but the usability and accesibility is very high.
+Simple terminologies can be managed in a **spreadsheet** (LibreOffice Calc, Excel, Google Sheets...). This software lacks most special functionality for terminology management but the usability and accessibility is very high. Some tools in the list below enhance standard spreadsheets with terminology management functionalities (e.g. vocexcel, voc4cat-tool).
 
 The same applies to **database management systems** (RDBMS, NoSQL, RDF triple stores, property graph databases...) with some additional features such as unique key constraints but less usability. An edge case might be systems for management of knowledge graphs (such as Semantic MediaWiki and Wikibase, [included above](#software)), and for personal knowledge management (such as Obsidian and Notion, not included above).
 
@@ -131,9 +131,10 @@ See [http://recremisi.blogspot.de/p/acrolinxterminology-lifecycle.html](http://r
 
 ## Acknowledgements
 
-Contributions to this report or to its precedessors have been provided by 
+Contributions to this report or to its predecessors have been provided by 
 Adrian Pohl,
 Antoine Isaac,
+David Linke,
 Eugene Morozov,
 Koen Van Daele,
 Matthias Löbe

--- a/kos-software.json
+++ b/kos-software.json
@@ -158,7 +158,7 @@
   {
     "name": "voc4cat-tool",
     "url": "https://github.com/nfdi4cat/voc4cat-tool/",
-    "platform": "CLI",
+    "platform": "CLI, GitHub",
     "api": false,
     "edit": true,
     "language": "Python",

--- a/kos-software.json
+++ b/kos-software.json
@@ -292,9 +292,9 @@
     "api": false,
     "edit": false,
     "language": "SHACL",
-    "license": "CC0",
-    "repository": "https://github.com/surroundaustralia/vocpub-profile",
-    "update": "2022"
+    "license": "CC-BY-4.0",
+    "repository": "https://github.com/AGLDWG/vocpub-profile/",
+    "update": "2024"
   },
   {
     "name": "Ginco",

--- a/kos-software.json
+++ b/kos-software.json
@@ -156,10 +156,11 @@
     "update": "2025"
   },
   {
-    "name": "Voc4cat",
+    "name": "voc4cat-tool",
+    "url": "https://github.com/nfdi4cat/voc4cat-tool/",
     "platform": "CLI",
     "api": false,
-    "edit": false,
+    "edit": true,
     "language": "Python",
     "license": "BSD-3",
     "repository": "https://github.com/nfdi4cat/voc4cat-tool/",
@@ -182,9 +183,9 @@
     "api": false,
     "edit": false,
     "language": "Python",
-    "license": "GPL",
-    "repository": "https://github.com/RDFLib/VocExcel",
-    "update": "2023"
+    "license": "BSD-3",
+    "repository": "https://github.com/Kurrawong/VocExcel",
+    "update": "2025"
   },
   {
     "name": "Atramhasis",


### PR DESCRIPTION
- added a link to voc4cat-tool
- update vocpub and vocexcel information (vocexcel changed its license from GPL to BSD-3 in 2023, see https://github.com/RDFLib/VocExcel/commit/43d00c86b79f65f5bd2567235d41e838cbcf435e)
- added a sentence on tools that make spreadsheets more suitable as editors

I added GitHub as platform for voc4cat-tool. Is putting two platforms as comma separated entries `"platform": "CLI, GitHub"` ok? 
